### PR TITLE
Add the SSL Wireless (ISMS Plus) gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Easily integrate multiple SMS gateways into your Laravel application with a unif
 - [Twilio](https://www.twilio.com)
 - [AlphaBd](https://alpha.net.bd/SMS/)
 - [BulkSmsDhaka](https://bulksmsdhaka.net)
+- [SSL Wireless (ISMS Plus)](https://ismsplus.sslwireless.com/api-documentation)
 - **Log** (for local/staging environments)
 
 ---
@@ -51,7 +52,7 @@ composer require enzaime/sms
 Add the following to your `.env` file:
 
 ```env
-SMS_DEFAULT_DRIVER=twilio|alpha_bd|bulk_sms_dhaka|log
+SMS_DEFAULT_DRIVER=twilio|alpha_bd|bulk_sms_dhaka|ssl_wireless|log
 
 TWILIO_SID=your-twilio-sid
 TWILIO_AUTH_TOKEN=your-twilio-auth-token
@@ -59,9 +60,69 @@ TWILIO_NUMBER=your-twilio-number
 
 BULKSMSDHAKA_API_KEY=your-bulksmsdhaka-api-key
 BULKSMSDHAKA_CALLER_ID=your-bulksmsdhaka-caller-id
+
+SSLWIRELESS_API_TOKEN=your-isms-plus-api-token
+SSLWIRELESS_SID=your-approved-sender-id
+# Only needed for the secure OTP route
+SSLWIRELESS_SECRET_KEY=your-isms-plus-secret-key
+# Optional; defaults to https://smsplus.sslwireless.com/api/v3
+SSLWIRELESS_API_URL=https://smsplus.sslwireless.com/api/v3
 ```
 
 > **Twilio:** Recipient number must be in international format (e.g., `+8801xxxxxxxxx`).
+
+---
+
+## SSL Wireless (ISMS Plus)
+
+```php
+EnzSms::driver('ssl_wireless')->send('01xxxxxxxxx', 'Testing');
+EnzSms::driver('ssl_wireless')->send(['01xxxxxxxxx', '01yyyyyyyyy'], 'Testing');
+```
+
+Things worth knowing before you point production at it:
+
+- **The sending IP must be whitelisted** in the ISMS Plus portal, or every
+  request comes back `4003 IP Blacklisted` — as an HTTP 200.
+- **`send()` returns the number of recipients the gateway accepted**, which is
+  not always the number it was handed: the gateway reports a verdict per
+  recipient in `smsinfo`, and every refusal is logged with its reason.
+- **Numbers are normalised to MSISDN form** (`01712345678` and
+  `+8801712345678` both become `8801712345678`), and a number repeated within
+  one call is sent once — the gateway refuses a duplicate rather than
+  delivering it twice.
+- **A list is split at 100 recipients per request**, the gateway's cap, and
+  goes to the bulk endpoint; a single number goes to the single-send endpoint.
+- Neither the API token nor the message body ever reaches a log line.
+
+### Secure OTP route
+
+One-time codes have their own endpoint, and it is worth using: the body is
+encrypted, the request is signed, and the gateway rate-limits it per recipient
+(code 4033) in a way the ordinary route does not.
+
+```php
+EnzSms::driver('ssl_wireless')->sendOtp('01xxxxxxxxx', 'Your code is 123456');
+```
+
+- Requires `SSLWIRELESS_SECRET_KEY` (the **Secret Key** from the portal, which
+  is not the API key). Without it `sendOtp()` refuses and logs — it will not
+  quietly fall back to the plain route and put the code on the wire in clear
+  text.
+- The body is AES-256-CBC encrypted under a key derived from the Secret Key,
+  with a fresh IV per message, and the request carries an HMAC-SHA256
+  `X-Signature`. A `4035` in the log means the signature did not match.
+- The route takes one recipient at a time; a list becomes one request each.
+- Drivers offering this expose `Enzaime\Sms\Contracts\OtpContract`, so a
+  caller can check before reaching for it:
+
+```php
+$driver = EnzSms::getDriver('ssl_wireless');
+
+if ($driver instanceof \Enzaime\Sms\Contracts\OtpContract) {
+    $driver->sendOtp($number, $code);
+}
+```
 
 ---
 

--- a/config/sms.php
+++ b/config/sms.php
@@ -20,5 +20,11 @@ return [
             'api_key' => env('BULKSMSDHAKA_API_KEY'),
             'api_url' => env('BULKSMSDHAKA_API_URL', 'https://bulksmsdhaka.net/api/sendtext'),
         ],
+        'sslwireless' => [
+            'sid' => env('SSLWIRELESS_SID'),
+            'api_token' => env('SSLWIRELESS_API_TOKEN'),
+            'secret_key' => env('SSLWIRELESS_SECRET_KEY'),
+            'api_url' => env('SSLWIRELESS_API_URL', 'https://smsplus.sslwireless.com/api/v3'),
+        ],
     ],
 ];

--- a/src/Contracts/OtpContract.php
+++ b/src/Contracts/OtpContract.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Enzaime\Sms\Contracts;
+
+/**
+ * Interface OtpContract
+ *
+ * For gateways that offer a hardened route for one-time codes, separate from
+ * ordinary traffic. A driver implements this only when the gateway has such a
+ * route; callers should check for it rather than assume it.
+ */
+interface OtpContract
+{
+    /**
+     * Send a one-time code over the gateway's secure route.
+     *
+     * Returns the number of recipients the gateway accepted.
+     */
+    public function sendOtp(string|array $numberOrList, string $text): int;
+}

--- a/src/Drivers/SslWireless.php
+++ b/src/Drivers/SslWireless.php
@@ -1,0 +1,551 @@
+<?php
+
+namespace Enzaime\Sms\Drivers;
+
+use Enzaime\Sms\Contracts\OtpContract;
+use Enzaime\Sms\Contracts\SmsContract;
+use Enzaime\Sms\Support\RedactsSensitiveValues;
+use Exception;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+/**
+ * SSL Wireless (ISMS Plus) driver integration.
+ *
+ * Unlike the other Bangladeshi gateways here, this one takes JSON over POST
+ * and answers with a per-recipient verdict: a request can be accepted at the
+ * transport level, report `SUCCESS` at the top level, and still refuse
+ * individual numbers inside `smsinfo`. The accepted count is therefore
+ * counted from those entries, not from the HTTP status.
+ *
+ * One-time codes have their own hardened route — see {@see sendOtp()} — which
+ * the plain send path deliberately does not use.
+ *
+ * @see https://ismsplus.sslwireless.com/api-documentation The API documentation.
+ */
+class SslWireless implements OtpContract, SmsContract
+{
+    use RedactsSensitiveValues;
+
+    /**
+     * The gateway refuses a bulk request outright (code 4030) above this many
+     * recipients, so a longer list is split across several requests.
+     */
+    public const MAX_RECIPIENTS_PER_REQUEST = 100;
+
+    /**
+     * Length of the client-side message id. The gateway caps it at 20
+     * alphanumeric characters and rejects a repeat (code 4023), so it is
+     * generated fresh per request rather than derived from the message.
+     */
+    public const CSMS_ID_LENGTH = 20;
+
+    /**
+     * The only top-level code that means "we have the message".
+     */
+    public const SUCCESS_STATUS_CODE = 200;
+
+    /**
+     * The per-recipient verdict that means accepted; everything else in
+     * `sms_status` (INVALID, DUPLICATE, BLOCKED) is a refusal.
+     */
+    public const ACCEPTED_SMS_STATUS = 'SUCCESS';
+
+    /**
+     * The secure OTP route encrypts the message body before it goes on the
+     * wire. PKCS#7 is OpenSSL's default padding for this cipher.
+     */
+    public const OTP_CIPHER = 'aes-256-cbc';
+
+    /**
+     * The initialisation vector is a fixed 16 raw bytes, and rides in front of
+     * the ciphertext rather than being agreed in advance.
+     */
+    public const OTP_IV_LENGTH = 16;
+
+    /**
+     * The parameters the OTP signature is computed over, in the order the
+     * gateway canonicalises them (alphabetical). The API token is
+     * deliberately absent: it authenticates the request, the signature
+     * attests to the message.
+     */
+    public const SIGNED_PARAMETERS = ['csms_id', 'msisdn', 'sid', 'sms'];
+
+    /**
+     * The gateway's documented codes, so a log line says what went wrong
+     * instead of leaving the reader to go and look it up.
+     */
+    public const CODE_MEANINGS = [
+        4001 => 'unauthorized: authentication failed',
+        4002 => 'sender ID not permitted to send SMS',
+        4003 => 'IP not whitelisted',
+        4004 => 'invalid request format',
+        4005 => 'endpoint not found',
+        4020 => 'invalid CSMS ID',
+        4022 => 'required parameter missing',
+        4023 => 'duplicate CSMS ID',
+        4024 => 'duplicate MSISDN',
+        4025 => 'invalid MSISDN',
+        4026 => 'blocked MSISDN',
+        4027 => 'message length exceeded',
+        4028 => 'invalid message data',
+        4029 => 'too many requests',
+        4030 => 'recipient limit exceeded for one request',
+        4031 => 'TPS limit exceeded',
+        4032 => 'invalid SMS body',
+        4033 => 'too many OTP requests to one recipient',
+        4034 => 'unable to decrypt SMS',
+        4035 => 'client signature mismatch',
+        5000 => 'internal server error at the gateway',
+    ];
+
+    /**
+     * Send SMS.
+     *
+     * Returns the number of recipients the gateway accepted, which is not
+     * necessarily the number it was handed.
+     */
+    public function send(string|array $numberOrList, string $text): int
+    {
+        $numbers = $this->prepareRecipients(is_array($numberOrList) ? $numberOrList : [$numberOrList]);
+
+        if ($numbers === []) {
+            return 0;
+        }
+
+        if (! is_array($numberOrList)) {
+            return $this->sendToOne($numbers[0], $text);
+        }
+
+        $accepted = 0;
+
+        foreach (array_chunk($numbers, self::MAX_RECIPIENTS_PER_REQUEST) as $chunk) {
+            $accepted += $this->sendToMany($chunk, $text);
+        }
+
+        return $accepted;
+    }
+
+    /**
+     * Send a one-time code over the gateway's secure route.
+     *
+     * This is not the same wire as {@see send()}. The message body is
+     * encrypted with a key derived from the account's Secret Key, and the
+     * request carries an HMAC signature over the parameters that matter, so
+     * neither the code nor its recipient can be read or altered in transit.
+     * The gateway also rate-limits this route per recipient (code 4033),
+     * which is the point of using it for codes and not for notices.
+     *
+     * The route takes one recipient at a time; a list becomes one request
+     * each.
+     */
+    public function sendOtp(string|array $numberOrList, string $text): int
+    {
+        $numbers = $this->prepareRecipients(is_array($numberOrList) ? $numberOrList : [$numberOrList]);
+
+        if ($numbers === []) {
+            return 0;
+        }
+
+        if ($this->getSecretKey() === '') {
+            // Without the Secret Key the body cannot be encrypted and the
+            // request cannot be signed. Falling back to the plain route would
+            // put the code on the wire in clear text, so refuse instead.
+            $this->reportFailure($numbers, [
+                'error_message' => 'no secret key configured for the secure OTP route',
+            ]);
+
+            return 0;
+        }
+
+        $accepted = 0;
+
+        foreach ($numbers as $msisdn) {
+            $accepted += $this->sendOtpToOne($msisdn, $text);
+        }
+
+        return $accepted;
+    }
+
+    /**
+     * Encrypt, sign and post one one-time code.
+     */
+    protected function sendOtpToOne(string $msisdn, string $text): int
+    {
+        $encrypted = $this->encryptOtpText($text);
+
+        if ($encrypted === null) {
+            $this->reportFailure([$msisdn], ['error_message' => 'could not encrypt the OTP body']);
+
+            return 0;
+        }
+
+        $payload = $this->credentials() + [
+            'msisdn' => $msisdn,
+            'sms' => $encrypted,
+            'csms_id' => $this->generateCsmsId(),
+        ];
+
+        return $this->dispatch('secure/otp-sms', $payload, [$msisdn], [
+            'X-Signature' => $this->signOtpPayload($payload),
+        ]);
+    }
+
+    /**
+     * Encrypt an OTP body for the secure route.
+     *
+     * The wire format is a base64 envelope wrapping the raw IV followed by
+     * the *already base64-encoded* ciphertext — the double encoding is the
+     * gateway's, not an accident. A fresh IV per message is what stops the
+     * same code to the same number producing the same bytes twice.
+     */
+    protected function encryptOtpText(string $text): ?string
+    {
+        $iv = random_bytes(self::OTP_IV_LENGTH);
+
+        $cipher = openssl_encrypt($text, self::OTP_CIPHER, $this->otpEncryptionKey(), 0, $iv);
+
+        if ($cipher === false) {
+            return null;
+        }
+
+        return base64_encode($iv.$cipher);
+    }
+
+    /**
+     * The AES key, derived from the account's Secret Key.
+     *
+     * The documentation's prose asks for the first 32 characters of the
+     * SHA-256 hex digest while its own sample passes the whole 64-character
+     * digest; in PHP those agree, because OpenSSL truncates an over-long key
+     * to the cipher's 32 bytes. The explicit form is used so the derivation
+     * does not depend on that truncation.
+     */
+    protected function otpEncryptionKey(): string
+    {
+        return substr(hash('sha256', $this->getSecretKey()), 0, 32);
+    }
+
+    /**
+     * The `X-Signature` for an OTP request: a lowercase HMAC-SHA256 hex
+     * digest over the canonical query string, keyed with the raw Secret Key.
+     *
+     * The key here is the Secret Key itself, *not* the SHA-256 derivation
+     * used for the cipher — the two are different keys from the same secret.
+     *
+     * @param  array<string, mixed>  $payload
+     */
+    protected function signOtpPayload(array $payload): string
+    {
+        $signed = array_intersect_key($payload, array_flip(self::SIGNED_PARAMETERS));
+
+        ksort($signed);
+
+        $canonical = [];
+
+        foreach ($signed as $name => $value) {
+            // RFC 3986 encoding, which is what the gateway's own samples
+            // produce. The signed values are digits, alphanumerics and
+            // base64, so the characters where PHP and JavaScript disagree
+            // cannot occur here.
+            $canonical[] = $name.'='.rawurlencode((string) $value);
+        }
+
+        return hash_hmac('sha256', implode('&', $canonical), $this->getSecretKey());
+    }
+
+    /**
+     * Send one message to a single recipient.
+     */
+    protected function sendToOne(string $msisdn, string $text): int
+    {
+        return $this->dispatch('send-sms', $this->credentials() + [
+            'msisdn' => $msisdn,
+            'sms' => $text,
+            'csms_id' => $this->generateCsmsId(),
+        ], [$msisdn]);
+    }
+
+    /**
+     * Send one message to a batch of recipients.
+     *
+     * @param  array<int, string>  $msisdns
+     */
+    protected function sendToMany(array $msisdns, string $text): int
+    {
+        return $this->dispatch('send-sms/bulk', $this->credentials() + [
+            'msisdn' => array_values($msisdns),
+            'sms' => $text,
+            'batch_csms_id' => $this->generateCsmsId(),
+        ], $msisdns);
+    }
+
+    /**
+     * Post one request and account for what came back.
+     *
+     * The payload arrives complete: the OTP route signs the exact bytes it
+     * posts, so nothing may be added to a request after it has been signed.
+     *
+     * @param  array<string, mixed>  $payload
+     * @param  array<int, string>  $recipients
+     * @param  array<string, string>  $headers
+     */
+    protected function dispatch(string $path, array $payload, array $recipients, array $headers = []): int
+    {
+        try {
+            $response = Http::withHeaders($headers)
+                ->acceptJson()
+                ->asJson()
+                ->post($this->getEndPoint($path), $payload);
+        } catch (Exception $ex) {
+            $this->reportFailure($recipients, ['exception' => $ex->getMessage()]);
+
+            return 0;
+        }
+
+        if (! $response->successful()) {
+            $this->reportFailure($recipients, [
+                'status' => $response->status(),
+                'response' => Str::limit($response->body(), 500),
+            ]);
+
+            return 0;
+        }
+
+        return $this->countAccepted($response->json(), $recipients, $response->status());
+    }
+
+    /**
+     * Count the recipients the gateway actually took.
+     *
+     * A 200 is not an accepted message: the gateway reserves the HTTP status
+     * for transport and reports the real outcome in the body, per recipient.
+     * "Invalid MSISDN" and "Blocked MSISDN" both arrive inside a perfectly
+     * successful response, so trusting the status alone counts refusals as
+     * deliveries.
+     *
+     * @param  mixed  $body
+     * @param  array<int, string>  $recipients
+     */
+    protected function countAccepted($body, array $recipients, int $httpStatus): int
+    {
+        if (! is_array($body)) {
+            // Nothing readable came back; the transport verdict is all there is.
+            return count($recipients);
+        }
+
+        $info = $body['smsinfo'] ?? null;
+
+        if (is_array($info) && $info !== []) {
+            return $this->countAcceptedEntries($info, $body, $httpStatus);
+        }
+
+        if ($this->isAccepted($body)) {
+            return count($recipients);
+        }
+
+        $this->reportFailure($recipients, $this->outcomeContext($body) + ['status' => $httpStatus]);
+
+        return 0;
+    }
+
+    /**
+     * Count the accepted entries in `smsinfo` and log every refused one.
+     *
+     * @param  array<int, mixed>  $info
+     * @param  array<string, mixed>  $body
+     */
+    protected function countAcceptedEntries(array $info, array $body, int $httpStatus): int
+    {
+        $accepted = 0;
+        $refused = [];
+
+        foreach ($info as $entry) {
+            $status = is_array($entry) ? (string) ($entry['sms_status'] ?? '') : '';
+
+            if (strtoupper($status) === self::ACCEPTED_SMS_STATUS) {
+                $accepted++;
+
+                continue;
+            }
+
+            $refused[] = [
+                'number' => is_array($entry) ? (string) ($entry['msisdn'] ?? '') : '',
+                'sms_status' => $status ?: 'unknown',
+                'status_message' => $this->redact(is_array($entry) ? (string) ($entry['status_message'] ?? '') : ''),
+            ];
+        }
+
+        foreach ($refused as $refusal) {
+            $this->reportFailure(
+                [$refusal['number']],
+                $this->outcomeContext($body) + [
+                    'status' => $httpStatus,
+                    'sms_status' => $refusal['sms_status'],
+                    'status_message' => $refusal['status_message'],
+                ]
+            );
+        }
+
+        return $accepted;
+    }
+
+    /**
+     * Whether a body without per-recipient detail says the request was taken.
+     *
+     * A body that carries neither key is not readable as a refusal, so the
+     * HTTP status stays the verdict.
+     *
+     * @param  array<string, mixed>  $body
+     */
+    protected function isAccepted(array $body): bool
+    {
+        if (isset($body['status_code']) && is_numeric($body['status_code'])) {
+            return (int) $body['status_code'] === self::SUCCESS_STATUS_CODE;
+        }
+
+        if (isset($body['status'])) {
+            return strtoupper((string) $body['status']) === self::ACCEPTED_SMS_STATUS;
+        }
+
+        return true;
+    }
+
+    /**
+     * The top-level verdict, spelled out for a log line.
+     *
+     * @param  array<string, mixed>  $body
+     * @return array<string, mixed>
+     */
+    protected function outcomeContext(array $body): array
+    {
+        $context = [];
+
+        if (isset($body['status_code']) && is_numeric($body['status_code'])) {
+            $code = (int) $body['status_code'];
+            $context['code'] = $code;
+            $context['meaning'] = self::CODE_MEANINGS[$code] ?? 'unknown code';
+        }
+
+        if (! empty($body['error_message'])) {
+            $context['error_message'] = $this->redact((string) $body['error_message']);
+        }
+
+        return $context;
+    }
+
+    /**
+     * Normalise, drop empties and de-duplicate a recipient list.
+     *
+     * A repeated number inside one request is refused as a duplicate — for a
+     * single send with code 4024, for a batch by failing the message data —
+     * so the repeat is dropped here rather than spent on a refusal.
+     *
+     * @param  array<int, string>  $numbers
+     * @return array<int, string>
+     */
+    protected function prepareRecipients(array $numbers): array
+    {
+        $normalized = array_map(fn (string $number): string => $this->normalizeMsisdn($number), $numbers);
+
+        return array_values(array_unique(array_filter($normalized, fn (string $number): bool => $number !== '')));
+    }
+
+    /**
+     * Put a number into the MSISDN form the gateway expects: digits only,
+     * carrying the country code and no leading `+` or `00`.
+     */
+    protected function normalizeMsisdn(string $number): string
+    {
+        $digits = (string) preg_replace('/\D+/', '', $number);
+
+        if ($digits === '' || str_starts_with($digits, '880')) {
+            return $digits;
+        }
+
+        if (str_starts_with($digits, '00')) {
+            return substr($digits, 2);
+        }
+
+        if (str_starts_with($digits, '0')) {
+            return '88'.$digits;
+        }
+
+        return $digits;
+    }
+
+    /**
+     * A fresh client-side message id. The gateway rejects a repeat, so this
+     * must vary per request even when the same text goes to the same number.
+     */
+    protected function generateCsmsId(): string
+    {
+        return Str::random(self::CSMS_ID_LENGTH);
+    }
+
+    /**
+     * Log a refused send.
+     *
+     * Never includes the message text or the API token: this driver carries
+     * one-time codes, and the gateway echoes both the request and the message
+     * body back in its own response. Everything taken off the wire is
+     * redacted first.
+     *
+     * @param  array<int, string>  $numbers
+     * @param  array<string, mixed>  $context
+     */
+    protected function reportFailure(array $numbers, array $context): void
+    {
+        foreach (['exception', 'response'] as $tainted) {
+            if (isset($context[$tainted])) {
+                $context[$tainted] = $this->redact((string) $context[$tainted]);
+            }
+        }
+
+        Log::error('[SMS][SslWireless] send failed', $context + ['number' => implode(',', $numbers)]);
+    }
+
+    /**
+     * Return sslwireless config
+     *
+     * @return array
+     */
+    protected function config()
+    {
+        return config('sms.drivers.sslwireless');
+    }
+
+    protected function getEndPoint(string $path): string
+    {
+        return rtrim($this->config()['api_url'], '/').'/'.ltrim($path, '/');
+    }
+
+    protected function getApiToken(): string
+    {
+        return $this->config()['api_token'] ?? '';
+    }
+
+    protected function getSenderId(): string
+    {
+        return $this->config()['sid'] ?? '';
+    }
+
+    protected function getSecretKey(): string
+    {
+        return (string) ($this->config()['secret_key'] ?? '');
+    }
+
+    /**
+     * The credentials every request carries.
+     *
+     * @return array<string, string>
+     */
+    protected function credentials(): array
+    {
+        return [
+            'api_token' => $this->getApiToken(),
+            'sid' => $this->getSenderId(),
+        ];
+    }
+}

--- a/src/Support/RedactsSensitiveValues.php
+++ b/src/Support/RedactsSensitiveValues.php
@@ -41,8 +41,9 @@ trait RedactsSensitiveValues
     /**
      * Replace the value of every sensitive parameter with a placeholder,
      * leaving the rest of the text — the part that says what went wrong —
-     * intact and useful. Both wire shapes are covered: `name=value` in a URL
-     * and `"name": "value"` in a JSON body.
+     * intact and useful. Three wire shapes are covered: `name=value` in a URL,
+     * `"name": "value"` in a JSON body, and `\"name\": \"value\"` for a body a
+     * gateway has echoed back inside a JSON string of its own.
      */
     protected function redact(string $text): string
     {
@@ -54,9 +55,21 @@ trait RedactsSensitiveValues
             $text
         );
 
-        return (string) preg_replace(
-            '/("(?:'.$names.')"\s*:\s*)"(?:\\\\.|[^"\\\\])*"/i',
+        /*
+         * The closing quote is optional. A response body is truncated before
+         * it is logged, and a cut landing inside a value would otherwise
+         * leave the pattern unmatched and the whole partial secret in place —
+         * which is the one case where the value on the wire is a live code.
+         */
+        $text = (string) preg_replace(
+            '/("(?:'.$names.')"\s*:\s*)"(?:\\\\.|[^"\\\\])*("|$)/i',
             '$1"[redacted]"',
+            $text
+        );
+
+        return (string) preg_replace(
+            '/(\\\\"(?:'.$names.')\\\\"\s*:\s*)\\\\"(?:\\\\\\\\.|(?!\\\\").)*(\\\\"|$)/i',
+            '$1\\"[redacted]\\"',
             $text
         );
     }

--- a/src/Support/RedactsSensitiveValues.php
+++ b/src/Support/RedactsSensitiveValues.php
@@ -5,44 +5,58 @@ namespace Enzaime\Sms\Support;
 /**
  * Strip secrets out of text on its way to a log.
  *
- * These drivers pass the API key *and* the message body as query parameters,
- * and an HTTP client puts the whole request URL into its exception message. So
- * the most ordinary failure there is — a timeout, a DNS miss — hands a log
- * line the credential and, when the message is a one-time code, the code too.
+ * These drivers pass the API key *and* the message body to the gateway — as
+ * query parameters for the GET-based ones, as JSON for SSL Wireless — and an
+ * HTTP client puts the whole request URL into its exception message. So the
+ * most ordinary failure there is — a timeout, a DNS miss — hands a log line
+ * the credential and, when the message is a one-time code, the code too.
  *
  * The same applies to a response body, since a gateway may echo the request
- * back. Anything derived from the wire is treated as tainted and passed
- * through here first.
+ * back; SSL Wireless returns the message it accepted in `sms_body`. Anything
+ * derived from the wire is treated as tainted and passed through here first.
  */
 trait RedactsSensitiveValues
 {
     /**
-     * Parameter names whose values must never be logged. Covers both drivers'
-     * spellings: `apikey` for Bulk SMS Dhaka, `api_key` for Alpha, `message`
-     * and `msg` for the body that may carry a one-time code.
+     * Parameter names whose values must never be logged. Covers every
+     * driver's spelling: `apikey` for Bulk SMS Dhaka, `api_key` for Alpha,
+     * `api_token` for SSL Wireless, and `message`/`msg`/`sms`/`sms_body`/
+     * `text` for the body that may carry a one-time code.
      */
     protected static $sensitiveParameters = [
         'apikey',
         'api_key',
+        'api_token',
         'message',
         'msg',
+        'sms',
+        'sms_body',
+        'text',
         'token',
         'secret',
+        'secret_key',
         'password',
     ];
 
     /**
-     * Replace the value of every sensitive query parameter with a placeholder,
+     * Replace the value of every sensitive parameter with a placeholder,
      * leaving the rest of the text — the part that says what went wrong —
-     * intact and useful.
+     * intact and useful. Both wire shapes are covered: `name=value` in a URL
+     * and `"name": "value"` in a JSON body.
      */
     protected function redact(string $text): string
     {
         $names = implode('|', array_map('preg_quote', static::$sensitiveParameters));
 
-        return (string) preg_replace(
+        $text = (string) preg_replace(
             '/\b('.$names.')=([^&\s"\'<>]*)/i',
             '$1=[redacted]',
+            $text
+        );
+
+        return (string) preg_replace(
+            '/("(?:'.$names.')"\s*:\s*)"(?:\\\\.|[^"\\\\])*"/i',
+            '$1"[redacted]"',
             $text
         );
     }

--- a/tests/Unit/SslWirelessTest.php
+++ b/tests/Unit/SslWirelessTest.php
@@ -273,6 +273,65 @@ class SslWirelessTest extends TestCase
     }
 
     /**
+     * A response body is truncated before it reaches the log, and the cut can
+     * land inside the very value that must not be logged. A pattern needing
+     * the closing quote would find none and leave the partial code in place.
+     */
+    public function test_a_body_truncated_mid_code_is_still_redacted(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response(
+                // Sized so the 500-character cut lands just past the code,
+                // leaving the value open: `"sms_body":"Your code is 55555`.
+                '{"status":"FAILED","status_code":4032,"error_message":"Invalid SMS","detail":"'
+                .str_repeat('x', 390).'","sms_body":"Your code is 55555"}',
+                503
+            ),
+        ]);
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->send('01912345678', 'Your code is 55555'));
+
+        $context = json_encode($logged[0]->context);
+
+        $this->assertStringContainsString('sms_body', $context, 'the cut has to fall inside the value');
+        $this->assertStringNotContainsString('55555', $context, 'a truncated code must not survive');
+        $this->assertStringContainsString('Invalid SMS', $context);
+    }
+
+    /**
+     * The gateway may echo the request back encoded inside a string of its
+     * own, which spells the keys `\"api_token\"` rather than `"api_token"`.
+     */
+    public function test_a_re_encoded_body_is_redacted(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response(
+                '{"status":"FAILED","error_message":"Invalid SMS","request":'
+                .'"{\\"api_token\\":\\"REAL-SECRET-TOKEN\\",\\"sms\\":\\"Your code is 55555\\"}"}',
+                503
+            ),
+        ]);
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->send('01912345678', 'Your code is 55555'));
+
+        $context = json_encode($logged[0]->context);
+
+        $this->assertStringNotContainsString('REAL-SECRET-TOKEN', $context);
+        $this->assertStringNotContainsString('55555', $context);
+        $this->assertStringContainsString('Invalid SMS', $context, 'what went wrong still has to survive');
+    }
+
+    /**
      * A repeated CSMS ID is refused by the gateway (code 4023), so the id has
      * to be fresh even when the same text goes to the same number twice.
      */

--- a/tests/Unit/SslWirelessTest.php
+++ b/tests/Unit/SslWirelessTest.php
@@ -1,0 +1,538 @@
+<?php
+
+namespace Enzaime\Sms\Tests\Unit;
+
+use Enzaime\Sms\Drivers\SslWireless;
+use Enzaime\Sms\Tests\TestCase;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class SslWirelessTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('sms.drivers.sslwireless', [
+            'sid' => 'ENZAIME',
+            'api_token' => 'test-api-token',
+            'secret_key' => 'test-secret-key',
+            'api_url' => 'https://smsplus.sslwireless.com/api/v3',
+        ]);
+    }
+
+    /**
+     * @param  array<int, array<string, string>>  $smsinfo
+     * @return array<string, mixed>
+     */
+    protected function successBody(array $smsinfo): array
+    {
+        return [
+            'status' => 'SUCCESS',
+            'status_code' => 200,
+            'error_message' => '',
+            'smsinfo' => $smsinfo,
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function acceptedFor(string $msisdn): array
+    {
+        return [
+            'sms_status' => 'SUCCESS',
+            'status_message' => 'Success',
+            'msisdn' => $msisdn,
+            'sms_type' => 'EN',
+            'reference_id' => '5da2f0b5ba3a2248110',
+        ];
+    }
+
+    public function test_sends_sms_to_a_single_number(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $sent = (new SslWireless)->send('01912345678', 'Hello world');
+
+        $this->assertSame(1, $sent);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://smsplus.sslwireless.com/api/v3/send-sms'
+                && $request->method() === 'POST'
+                && $request['api_token'] === 'test-api-token'
+                && $request['sid'] === 'ENZAIME'
+                // The gateway wants an MSISDN carrying the country code; a
+                // shop types the number the local way.
+                && $request['msisdn'] === '8801912345678'
+                && $request['sms'] === 'Hello world'
+                && is_string($request['csms_id'])
+                && strlen($request['csms_id']) === SslWireless::CSMS_ID_LENGTH;
+        });
+    }
+
+    public function test_a_list_goes_to_the_bulk_endpoint_in_one_request(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+                $this->acceptedFor('8801812345678'),
+            ]), 200),
+        ]);
+
+        $sent = (new SslWireless)->send(['01912345678', '+8801812345678'], 'Hello world');
+
+        $this->assertSame(2, $sent);
+
+        Http::assertSentCount(1);
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://smsplus.sslwireless.com/api/v3/send-sms/bulk'
+                && $request['msisdn'] === ['8801912345678', '8801812345678']
+                && is_string($request['batch_csms_id']);
+        });
+    }
+
+    /**
+     * The gateway refuses a batch outright above its recipient cap (code
+     * 4030), so a longer list has to be split rather than handed over whole.
+     */
+    public function test_a_list_longer_than_the_cap_is_split_across_requests(): void
+    {
+        $numbers = [];
+        for ($i = 0; $i < SslWireless::MAX_RECIPIENTS_PER_REQUEST + 5; $i++) {
+            $numbers[] = '019'.str_pad((string) $i, 8, '0', STR_PAD_LEFT);
+        }
+
+        Http::fake(function (Request $request) {
+            $info = [];
+            foreach ($request['msisdn'] as $msisdn) {
+                $info[] = $this->acceptedFor($msisdn);
+            }
+
+            return Http::response($this->successBody($info), 200);
+        });
+
+        $sent = (new SslWireless)->send($numbers, 'Hello world');
+
+        $this->assertSame(count($numbers), $sent);
+        Http::assertSentCount(2);
+    }
+
+    public function test_a_repeated_number_is_only_sent_once(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $sent = (new SslWireless)->send(['01912345678', '+8801912345678'], 'Hello world');
+
+        $this->assertSame(1, $sent, 'a duplicate MSISDN is refused by the gateway, not delivered twice');
+
+        Http::assertSent(fn (Request $request) => $request['msisdn'] === ['8801912345678']);
+    }
+
+    public function test_returns_zero_when_the_request_fails(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response('Server Error', 500),
+        ]);
+
+        $this->assertSame(0, (new SslWireless)->send('01912345678', 'Hello world'));
+    }
+
+    /**
+     * The gateway answers 200 and puts the real verdict in the body, so a
+     * refusal — "Invalid MSISDN", "IP not whitelisted" — arrives as a
+     * perfectly successful HTTP response.
+     */
+    public function test_a_failed_status_in_a_200_body_is_not_a_delivery(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response([
+                'status' => 'FAILED',
+                'status_code' => 4003,
+                'error_message' => 'IP Blacklisted',
+                'smsinfo' => [],
+            ], 200),
+        ]);
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->send('01912345678', 'Hello world'));
+
+        $this->assertCount(1, $logged);
+        $this->assertSame(4003, $logged[0]->context['code']);
+        $this->assertSame('IP not whitelisted', $logged[0]->context['meaning']);
+    }
+
+    /**
+     * A batch is accounted for per recipient: the top level can say SUCCESS
+     * while individual numbers inside it are refused.
+     */
+    public function test_only_the_accepted_entries_of_a_batch_are_counted(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+                [
+                    'sms_status' => 'INVALID',
+                    'status_message' => 'Invalid MSISDN',
+                    'msisdn' => '8801812345678',
+                    'sms_type' => 'EN',
+                ],
+            ]), 200),
+        ]);
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $sent = (new SslWireless)->send(['01912345678', '01812345678'], 'Hello world');
+
+        $this->assertSame(1, $sent, 'one of the two recipients was refused');
+
+        $this->assertCount(1, $logged, 'only the refused recipient is logged');
+        $this->assertSame('8801812345678', $logged[0]->context['number']);
+        $this->assertSame('INVALID', $logged[0]->context['sms_status']);
+    }
+
+    /**
+     * Not every response is readable, and a body we cannot parse must not be
+     * turned into a failure — the HTTP status remains the fallback verdict.
+     */
+    public function test_a_body_without_a_verdict_falls_back_to_the_http_status(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response('OK', 200),
+        ]);
+
+        $this->assertSame(1, (new SslWireless)->send('01912345678', 'Hello world'));
+    }
+
+    /**
+     * This gateway echoes the accepted message back in `sms_body`, so the
+     * response itself carries the one-time code straight into the log.
+     */
+    public function test_a_refusal_is_logged_without_the_message_or_the_token(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response(
+                '{"status":"FAILED","status_code":4032,"error_message":"Invalid SMS",'
+                .'"api_token":"REAL-SECRET-TOKEN","sms_body":"Your code is 55555"}',
+                503
+            ),
+        ]);
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->send('01912345678', 'Your code is 55555'));
+
+        $context = json_encode($logged[0]->context);
+
+        $this->assertStringNotContainsString('REAL-SECRET-TOKEN', $context, 'the API token must never reach the log');
+        $this->assertStringNotContainsString('55555', $context, 'the one-time code must never reach the log');
+        $this->assertStringContainsString('Invalid SMS', $context, 'what went wrong still has to survive');
+        $this->assertStringContainsString('[redacted]', $context);
+    }
+
+    public function test_a_transport_failure_logs_neither_the_token_nor_the_code(): void
+    {
+        Http::fake(fn () => throw new ConnectionException(
+            'cURL error 28: Operation timed out for https://smsplus.sslwireless.com/api/v3/send-sms'
+            .' with body {"api_token":"REAL-SECRET-TOKEN","sms":"Verification code: 55555."}'
+        ));
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->send('01912345678', 'Verification code: 55555.'));
+
+        $context = json_encode($logged[0]->context);
+
+        $this->assertStringNotContainsString('REAL-SECRET-TOKEN', $context);
+        $this->assertStringNotContainsString('55555', $context);
+        $this->assertStringContainsString('Operation timed out', $context);
+    }
+
+    /**
+     * A repeated CSMS ID is refused by the gateway (code 4023), so the id has
+     * to be fresh even when the same text goes to the same number twice.
+     */
+    public function test_each_request_carries_a_fresh_message_id(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $driver = new SslWireless;
+        $driver->send('01912345678', 'Hello world');
+        $driver->send('01912345678', 'Hello world');
+
+        $ids = [];
+        Http::assertSent(function (Request $request) use (&$ids) {
+            $ids[] = $request['csms_id'];
+
+            return true;
+        });
+
+        $this->assertCount(2, array_unique($ids));
+    }
+
+    public function test_an_unusable_number_is_never_sent(): void
+    {
+        Http::fake();
+
+        $this->assertSame(0, (new SslWireless)->send('', 'Hello world'));
+
+        Http::assertNothingSent();
+    }
+
+    public function test_the_driver_is_resolvable_by_name(): void
+    {
+        $this->assertInstanceOf(
+            SslWireless::class,
+            (new \Enzaime\Sms\SmsService)->getDriver('ssl_wireless')
+        );
+    }
+
+    /**
+     * Undo the documented envelope, following the specification rather than
+     * the driver: base64 off, 16 raw IV bytes off the front, and what is left
+     * is the base64 ciphertext under a key that is the first 32 characters of
+     * the SHA-256 hex digest of the Secret Key.
+     */
+    protected function decryptOtpText(string $encrypted, string $secretKey = 'test-secret-key'): string
+    {
+        $envelope = base64_decode($encrypted, true);
+
+        $this->assertNotFalse($envelope, 'the OTP body must be a base64 envelope');
+
+        $iv = substr($envelope, 0, 16);
+        $cipher = substr($envelope, 16);
+
+        return (string) openssl_decrypt(
+            $cipher,
+            'aes-256-cbc',
+            substr(hash('sha256', $secretKey), 0, 32),
+            0,
+            $iv
+        );
+    }
+
+    /**
+     * Rebuild the signature straight from the documented steps: the four
+     * signed parameters in alphabetical order, URL-encoded, HMAC-SHA256 under
+     * the raw Secret Key, lowercase hex.
+     */
+    protected function expectedSignature(Request $request, string $secretKey = 'test-secret-key'): string
+    {
+        $canonical = sprintf(
+            'csms_id=%s&msisdn=%s&sid=%s&sms=%s',
+            rawurlencode($request['csms_id']),
+            rawurlencode($request['msisdn']),
+            rawurlencode($request['sid']),
+            rawurlencode($request['sms'])
+        );
+
+        return hash_hmac('sha256', $canonical, $secretKey);
+    }
+
+    public function test_an_otp_goes_to_the_secure_route_with_an_encrypted_body(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $sent = (new SslWireless)->sendOtp('01912345678', 'Your code is 55555');
+
+        $this->assertSame(1, $sent);
+
+        Http::assertSent(function (Request $request) {
+            $this->assertSame('https://smsplus.sslwireless.com/api/v3/secure/otp-sms', $request->url());
+            $this->assertSame('test-api-token', $request['api_token']);
+            $this->assertSame('8801912345678', $request['msisdn']);
+
+            // The whole point of this route: the code is not on the wire.
+            $this->assertStringNotContainsString('55555', $request['sms']);
+            $this->assertSame('Your code is 55555', $this->decryptOtpText($request['sms']));
+
+            return true;
+        });
+    }
+
+    public function test_the_otp_request_is_signed_as_documented(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        (new SslWireless)->sendOtp('01912345678', 'Your code is 55555');
+
+        Http::assertSent(function (Request $request) {
+            $signature = $request->header('X-Signature')[0] ?? '';
+
+            $this->assertSame($this->expectedSignature($request), $signature);
+            $this->assertSame(strtolower($signature), $signature, 'the digest is a lowercase hex string');
+            $this->assertSame(64, strlen($signature));
+
+            return true;
+        });
+    }
+
+    /**
+     * A fresh IV per message is the only thing stopping the same code to the
+     * same number from producing identical ciphertext twice — which would
+     * make the codes comparable to anyone watching the traffic.
+     */
+    public function test_the_same_code_encrypts_differently_each_time(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $driver = new SslWireless;
+        $driver->sendOtp('01912345678', 'Your code is 55555');
+        $driver->sendOtp('01912345678', 'Your code is 55555');
+
+        $bodies = [];
+        Http::assertSent(function (Request $request) use (&$bodies) {
+            $bodies[] = $request['sms'];
+
+            return true;
+        });
+
+        $this->assertCount(2, array_unique($bodies), 'each message needs its own IV');
+        $this->assertSame('Your code is 55555', $this->decryptOtpText($bodies[0]));
+        $this->assertSame('Your code is 55555', $this->decryptOtpText($bodies[1]));
+    }
+
+    /**
+     * The secure route takes one recipient at a time.
+     */
+    public function test_an_otp_to_a_list_is_one_request_per_recipient(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $sent = (new SslWireless)->sendOtp(['01912345678', '01812345678'], 'Your code is 55555');
+
+        $this->assertSame(2, $sent);
+        Http::assertSentCount(2);
+    }
+
+    /**
+     * Without the Secret Key the body cannot be encrypted and the request
+     * cannot be signed. Quietly falling back to the plain route would put the
+     * code on the wire in clear text.
+     */
+    public function test_an_otp_is_refused_when_no_secret_key_is_configured(): void
+    {
+        config()->set('sms.drivers.sslwireless.secret_key', null);
+
+        Http::fake();
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->sendOtp('01912345678', 'Your code is 55555'));
+
+        Http::assertNothingSent();
+        $this->assertStringContainsString('secret key', $logged[0]->context['error_message']);
+    }
+
+    public function test_a_signature_mismatch_is_reported_with_its_meaning(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response([
+                'status' => 'FAILED',
+                'error_message' => 'Client signature mismatch',
+                'status_code' => 4035,
+                'smsinfo' => [],
+            ], 200),
+        ]);
+
+        $logged = [];
+        Log::listen(function ($event) use (&$logged) {
+            $logged[] = $event;
+        });
+
+        $this->assertSame(0, (new SslWireless)->sendOtp('01912345678', 'Your code is 55555'));
+
+        $this->assertSame(4035, $logged[0]->context['code']);
+        $this->assertSame('client signature mismatch', $logged[0]->context['meaning']);
+        $this->assertStringNotContainsString('55555', json_encode($logged[0]->context));
+    }
+
+    /**
+     * The plain send path must never be quietly upgraded to the secure route,
+     * nor the reverse: they are different endpoints with different limits.
+     */
+    public function test_a_plain_send_does_not_use_the_secure_route(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        (new SslWireless)->send('01912345678', 'Hello world');
+
+        Http::assertSent(function (Request $request) {
+            return $request->url() === 'https://smsplus.sslwireless.com/api/v3/send-sms'
+                && $request->header('X-Signature') === [];
+        });
+    }
+
+    public function test_the_driver_offers_the_otp_contract(): void
+    {
+        $this->assertInstanceOf(\Enzaime\Sms\Contracts\OtpContract::class, new SslWireless);
+    }
+
+    /**
+     * `SmsService` forwards an unknown method to the resolved driver, which is
+     * how a caller reaches the secure route through the facade.
+     */
+    public function test_the_otp_route_is_reachable_through_the_service(): void
+    {
+        Http::fake([
+            'smsplus.sslwireless.com/*' => Http::response($this->successBody([
+                $this->acceptedFor('8801912345678'),
+            ]), 200),
+        ]);
+
+        $sent = (new \Enzaime\Sms\SmsService)->driver('ssl_wireless')->sendOtp('01912345678', 'Your code is 55555');
+
+        $this->assertSame(1, $sent);
+    }
+}


### PR DESCRIPTION
Adds `ssl_wireless` as a fourth gateway, with a separate hardened route for one-time codes.

```php
EnzSms::driver('ssl_wireless')->send('01xxxxxxxxx', 'Testing');
EnzSms::driver('ssl_wireless')->sendOtp('01xxxxxxxxx', 'Your code is 123456');
```

## What is worth a reviewer's attention

**A 200 is not a delivery.** This gateway reserves the HTTP status for transport and reports the real outcome per recipient in `smsinfo`, so "Invalid MSISDN", "Blocked MSISDN" and "IP Blacklisted" all arrive inside a perfectly successful response. `send()` returns the number of recipients the gateway actually accepted, counted from those entries, and logs every refusal with the meaning of its code. This is the same trap #5 fixed for Bulk SMS Dhaka, one level deeper.

**Numbers are normalised and de-duplicated before sending.** `01712345678` and `+8801712345678` are the same MSISDN, and the gateway refuses the repeat rather than delivering it twice — so the repeat is dropped here instead of being spent on a refusal. A list is split at the documented cap of 100 recipients per request.

**OTPs do not go over the plain route.** The secure endpoint encrypts the body (AES-256-CBC, fresh IV per message) and signs the request (HMAC-SHA256 over the four canonical parameters), and the gateway rate-limits it per recipient in a way the ordinary route does not. Without `SSLWIRELESS_SECRET_KEY` the body cannot be encrypted and the request cannot be signed, so `sendOtp()` refuses and logs rather than quietly falling back and putting the code on the wire in clear text. Drivers offering this expose the new `OtpContract`, so a caller can check rather than assume.

## Second commit: two holes in the redaction

The driver carries live one-time codes, so the trait's promise that neither the code nor the API key reaches a log line has to actually hold. Reviewing the first commit turned up two shapes where it did not, both because the JSON pattern required a closing quote:

- **A truncated body.** The response is cut to 500 characters before it is redacted. A cut landing inside a value left the pattern unmatched and the partial code in place.
- **A re-encoded body.** The trait exists because a gateway may echo the request back; when it echoes it *encoded*, the keys arrive as `\"api_token\"` and went unmatched entirely.

Both tests fail on the previous pattern and pass on the new one — verified by reverting the fix and re-running.

## Still open, deliberately not in this PR

1. **The OTP crypto is only self-verified.** The test rebuilds the envelope and signature from the same assumptions the driver encodes, which proves internal consistency, not agreement with the gateway. A mismatch would surface only as `4034`/`4035` in production. **This wants one live sandbox send before anything is pointed at production.**
2. **A published `config/sms.php` loses the driver.** `mergeConfigFrom` is a shallow merge, so an app that published the config before this change has a `drivers` array with no `sslwireless` key; `getEndPoint()` then degrades to a relative path instead of failing loudly. Pre-existing shape, newly reachable.
3. **Two silent zeroes.** An all-unusable recipient list returns `0` with nothing logged, and if `smsinfo` returns fewer entries than recipients the remainder is neither counted nor logged.

Sending IPs must be whitelisted in the ISMS Plus portal or every request comes back `4003` — as an HTTP 200.

## Testing

41 tests, 110 assertions, all passing. Pint clean.

https://claude.ai/code/session_01JGKNAfHkwfQyVdXbGatCjw